### PR TITLE
Add watsonx backend and include model in yaml file

### DIFF
--- a/src/fact_reasoner/configs/models.yaml
+++ b/src/fact_reasoner/configs/models.yaml
@@ -84,8 +84,15 @@ HF_MODELS:
 WX_MODELS:
   mixtral-8x22b-instruct:
     model_id: "watsonx/mistralai/Mixtral-8x22B-Instruct-v0.1"
-    api_base: "https://watsonx.ibm.com/mixtral-8x22b-instruct-v01/v1"
+    api_base: ""
     max_new_tokens: 16384
+    prompt_template: "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+    prompt_begin: "<|begin_of_text|><|start_header_id|>user<|end_header_id|>"
+    prompt_end: "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+  llama-3.3-70b-instruct:
+    model_id: "watsonx/meta-llama/llama-3-3-70b-instruct"
+    api_base: ""
+    max_new_tokens: 128000
     prompt_template: "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{}<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
     prompt_begin: "<|begin_of_text|><|start_header_id|>user<|end_header_id|>"
     prompt_end: "<|eot_id|><|start_header_id|>assistant<|end_header_id|>"


### PR DESCRIPTION
This PR enables using the watsonx backend.

It modifies the code for the `LLMHandler` to perform some custom parameter setting when using RITS, e.g. passing the API key to extra headers and ensuring there is an `api_base` string. As far as I know, such a string is not needed for WatsonX. I tried to bundle up all the generic code for API model options together but also included some necessary RITs-specific blocks.

It requires adding `WX_API_KEY=xxy` to the `.env` file.

I have verified that the `wx` backend is working using the atom extractor as an example:

```
    model_id = "llama-3.3-70b-instruct"
    prompt_version = "v2"
    backend = "wx"
```

```bash
python src/fact_reasoner/atom_extractor.py 

[LLMHandler] Initialization completed.
[AtomExtractor] Using LLM on wx: llama-3.3-70b-instruct
[AtomExtractor] Using prompt version: v2
[AtomExtractor] Prompts created: 1
Number of atoms: 10
0: [Fact] - The Apollo 14 mission to the Moon took place on January 31, 1971
1: [Fact] - The Apollo 14 mission marked the third time humans set foot on the lunar surface
2: [Fact] - Astronauts Alan Shepard and Edgar Mitchell joined Captain Stuart Roosa on the Apollo 14 mission
3: [Fact] - Captain Stuart Roosa had previously flown on Apollo 13
4: [Fact] - The mission lasted for approximately 8 days
5: [Fact] - The crew conducted various experiments during the Apollo 14 mission
6: [Fact] - The crew collected samples from the lunar surface during the Apollo 14 mission
7: [Fact] - Apollo 14 brought back approximately 70 kilograms of lunar material
8: [Fact] - The lunar material brought back by Apollo 14 included rocks, soil, and core samples
9: [Claim] - The lunar material brought back by Apollo 14 has been invaluable for scientific research
```