### PR TITLE
fix(nli): logprobs extraction from openai backend

### DIFF
--- a/src/fact_reasoner/utils.py
+++ b/src/fact_reasoner/utils.py
@@ -169,7 +169,7 @@ def extract_logprobs_from_output(output: Dict[str, Any]) -> List[Any]:
     # handle different logprobs formats across backends
     logprobs_object = (
         output._meta.get("logprobs")
-        or output._meta.get("chat_response", {}).get("logprobs")
+        or output._meta.get("chat_response", {}).get("choices", [{}])[0].get("logprobs")
         or output._meta.get("oai_chat_response", {}).get("logprobs")
         or output._meta.get("litellm_chat_response", {}).get("logprobs")
     )

--- a/src/fact_reasoner/utils.py
+++ b/src/fact_reasoner/utils.py
@@ -169,8 +169,8 @@ def extract_logprobs_from_output(output: Dict[str, Any]) -> List[Any]:
     # handle different logprobs formats across backends
     logprobs_object = (
         output._meta.get("logprobs")
-        or output._meta.get("chat_response", {}).get("choices", [{}])[0].get("logprobs")
-        or output._meta.get("oai_chat_response", {}).get("logprobs")
+        or output._meta.get("chat_response", {}).get("logprobs")
+        or output._meta.get("oai_chat_response", {}).get("choices", [{}])[0].get("logprobs")
         or output._meta.get("litellm_chat_response", {}).get("logprobs")
     )
 


### PR DESCRIPTION
The `NLIExtractor` raises an assertion error when used with RITS (or, presumably, any OpenAI-derived backend).

How to reproduce:

```py
    from mellea_ibm.rits import RITSBackend, RITS
    from fact_reasoner.core.nli import NLIExtractor

    backend = RITSBackend(
        RITS.LLAMA_3_3_70B_INSTRUCT,
        model_options={ModelOption.MAX_NEW_TOKENS: 4096}
    )

    nli = NLIExtractor(backend)

    response_atoms = [
        "The Eiffel Tower is located in Berlin.",
        "The Colosseum is located in Paris."
    ]
    correction = "The Eiffel Tower is located in Paris, while the Colosseum is located in Rome."

    nli = NLIExtractor(backend)
    for atom in response_atoms:
        nli_dict = nli.run(correction, atom)
        nli_label = nli_dict['label']
        print(f"NLI label for atom '{atom}': {nli_label}")
```